### PR TITLE
Dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
     target-branch: "dev"
   - package-ecosystem: "github-actions"
-    directory: ".github/"
+    directory: "/"
     schedule:
       interval: "monthly"
     target-branch: "dev"

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -2,7 +2,7 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: 
+    branches:
       - "main"
       - "dev"
 
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: super-linter/super-linter@v5
+        uses: super-linter/super-linter@v7
         env:
           FILTER_REGEX_EXCLUDE: .*(static|scss|venv|locale)/.*
           DEFAULT_BRANCH: main
@@ -37,7 +37,7 @@ jobs:
           VALIDATE_PYTHON_FLAKE8: true
 
   build-and-push-image:
-    needs: ['linter']
+    needs: ["linter"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,12 +56,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5.6.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6.9.0
         with:
           context: .
           push: true

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -31,7 +31,7 @@ jobs:
           FILTER_REGEX_EXCLUDE: .*(static|scss|venv|locale)/.*
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: falses
+          VALIDATE_ALL_CODEBASE: false
           LINTER_RULES_PATH: /app
           PYTHON_FLAKE8_CONFIG_FILE: .flake8
           VALIDATE_PYTHON_FLAKE8: true
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,12 +56,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5.6.1
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/app/db/requests.py
+++ b/app/db/requests.py
@@ -3,14 +3,13 @@ from sqlalchemy.exc import SQLAlchemyError
 from .models import Fumo
 from sqlalchemy import select, delete, update
 from typing import Optional
-from utils.escape_for_markdown import escape_markdown
 
 _fumo_ids_cache = None
 
 
 async def db_add_fumo(session: AsyncSession, name: str, file_id: str, source_link: Optional[str]) -> str:
     try:
-        fumo = Fumo(name=escape_markdown(name), file_id=file_id, source_link=source_link)
+        fumo = Fumo(name=name, file_id=file_id, source_link=source_link)
         session.add(fumo)
         await session.commit()
         return f"Fumo {name} added successfully."
@@ -40,13 +39,13 @@ async def db_show_all_fumos(session: AsyncSession) -> list[Fumo]:
 
 
 async def db_search_fumos_by_name(session: AsyncSession, search_pattern: str) -> Optional[Fumo]:
-    result = await session.execute(select(Fumo).where(Fumo.name.like(f'%{escape_markdown(search_pattern)}%')))
+    result = await session.execute(select(Fumo).where(Fumo.name.like(f'%{search_pattern}%')))
     return result.scalars().all()
 
 
 async def db_delete_fumo_by_name(session: AsyncSession, fumo_name: str) -> str:
     try:
-        await session.execute(delete(Fumo).where(Fumo.name == escape_markdown(fumo_name)))
+        await session.execute(delete(Fumo).where(Fumo.name == fumo_name))
         await session.commit()
         return f"Fumo {fumo_name} deleted."
     except SQLAlchemyError as e:
@@ -57,8 +56,8 @@ async def db_delete_fumo_by_name(session: AsyncSession, fumo_name: str) -> str:
 async def db_update_fumo_name(session: AsyncSession, old_fumo_name: str, new_fumo_name: str) -> str:
     try:
         await session.execute(update(Fumo).
-                              where(Fumo.name == escape_markdown(old_fumo_name))
-                              .values(name=escape_markdown(new_fumo_name)))
+                              where(Fumo.name == old_fumo_name)
+                              .values(name=new_fumo_name))
         await session.commit()
         return f"{new_fumo_name} name updated."
     except SQLAlchemyError as e:
@@ -69,7 +68,7 @@ async def db_update_fumo_name(session: AsyncSession, old_fumo_name: str, new_fum
 async def db_update_fumo_file_id_by_name(session: AsyncSession, fumo_name: str, new_fumo_file_id: str) -> str:
     try:
         await session.execute(update(Fumo).
-                              where(Fumo.name == escape_markdown(fumo_name)).
+                              where(Fumo.name == fumo_name).
                               values(file_id=new_fumo_file_id))
         await session.commit()
         return f"{fumo_name} image updated."
@@ -81,7 +80,7 @@ async def db_update_fumo_file_id_by_name(session: AsyncSession, fumo_name: str, 
 async def db_update_fumo_source_link_by_name(session: AsyncSession, fumo_name: str, new_source_link: str) -> str:
     try:
         await session.execute(update(Fumo).
-                              where(Fumo.name == escape_markdown(fumo_name)).
+                              where(Fumo.name == fumo_name).
                               values(source_link=new_source_link))
         await session.commit()
         return f"{fumo_name} url updated."

--- a/app/handlers/fumofumo.py
+++ b/app/handlers/fumofumo.py
@@ -6,6 +6,7 @@ from db.requests import db_get_fumo_by_id
 from sqlalchemy.ext.asyncio import AsyncSession
 from aiogram.enums import ParseMode
 import hashlib
+from utils.escape_for_markdown import escape_markdown
 
 router = Router()
 
@@ -26,5 +27,5 @@ async def fumofumo(message: types.Message, session: AsyncSession) -> None:
     fumo = await db_get_fumo_by_id(session, fumo_id)
     await message.reply_photo(
         photo=fumo.file_id,
-        caption=Messages.fumofumo_message.format(fumo=f"[{fumo.name}]({fumo.source_link})"),
+        caption=Messages.fumofumo_message.format(fumo=f"[{escape_markdown(fumo.name)}]({fumo.source_link})"),
         parse_mode=ParseMode.MARKDOWN_V2)

--- a/app/handlers/private_admin.py
+++ b/app/handlers/private_admin.py
@@ -14,6 +14,7 @@ from db.requests import db_update_fumo_source_link_by_name
 from aiogram.filters import and_f, invert_f
 from keyboards.edit_fumos_in_db import edit_buttons, confirm_buttons
 from aiogram.enums import ParseMode
+from utils.escape_for_markdown import escape_markdown
 
 router = Router()
 router.message.filter(AdminFilter())
@@ -89,7 +90,7 @@ async def show_all_fumos(message: types.Message, command: CommandObject, session
     for fumo in fumos:
         await message.answer_photo(
             photo=fumo.file_id,
-            caption=f"[{fumo.name}]({fumo.source_link})",
+            caption=f"[{escape_markdown(fumo.name)}]({fumo.source_link})",
             reply_markup=edit_buttons(),
             parse_mode=ParseMode.MARKDOWN_V2
         )
@@ -153,7 +154,7 @@ async def edit_fumo_name(message: Message, session: AsyncSession, state: FSMCont
     if message_to_edit.caption_entities is not None:
         fumo_link = message_to_edit.caption_entities[0].url
     await message_to_edit.edit_caption(
-        caption=f"[{new_fumo_name}]({fumo_link})",
+        caption=f"[{escape_markdown(new_fumo_name)}]({fumo_link})",
         reply_markup=message_to_edit.reply_markup,
         parse_mode=ParseMode.MARKDOWN_V2
     )
@@ -185,7 +186,7 @@ async def edit_fumo_image(message: Message, session: AsyncSession, state: FSMCon
         media=input_media_photo.InputMediaPhoto(
             type="photo",
             media=new_fumo_file_id,
-            caption=fumo_name,
+            caption=escape_markdown(fumo_name),
             caption_entities=message_to_edit.caption_entities
         ),
         reply_markup=message_to_edit.reply_markup,
@@ -215,7 +216,7 @@ async def edit_fumo_source_link(message: Message, session: AsyncSession, state: 
     new_fumo_source_link = message.text
     result = await db_update_fumo_source_link_by_name(session, fumo_name, new_fumo_source_link)
     await message_to_edit.edit_caption(
-        caption=f"[{fumo_name}]({new_fumo_source_link})",
+        caption=f"[{escape_markdown(fumo_name)}]({new_fumo_source_link})",
         reply_markup=message_to_edit.reply_markup,
         parse_mode=ParseMode.MARKDOWN_V2
     )

--- a/app/utils/escape_for_markdown.py
+++ b/app/utils/escape_for_markdown.py
@@ -7,5 +7,5 @@ def escape_markdown(text: str) -> str:
     '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!'
     must be escaped with the preceding character '\'.
     '''
-    special_chars = r"[\_\*\[\]\(\)\~\`\>\#\+\-\=\|\{\}\.\!]"
+    special_chars = r"[\\\_\*\[\]\(\)\~\`\>\#\+\-\=\|\{\}\.\!]"
     return re.sub(special_chars, r"\\\g<0>", text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-aiogram==3.10.0
+aiogram==3.15.0
 asyncio==3.4.3
-pydantic==2.10.1
 pydantic-settings==2.6.1
 PyYAML==6.0.1
 Alembic==1.14.0


### PR DESCRIPTION
fix workflow
change Markdown logic. 
Store escaped markdown was bad idea, it leads to a lot of bugs. So now I store only text in db. 
And escape it on sending messages with Markdown. So now text from db can be safely sent without style
If database already have escaped markdown, you can remove it using command
```
UPDATE fumo SET name = REPLACE(name, '\', '');
```